### PR TITLE
Prevent a lot of irrelevant compiler warnings.

### DIFF
--- a/.Config/Templates.gen/AndroidGradleCMake/CMake/Snippet_TargetCompileOptions_Default.txt
+++ b/.Config/Templates.gen/AndroidGradleCMake/CMake/Snippet_TargetCompileOptions_Default.txt
@@ -1,5 +1,5 @@
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   target_compile_options(##PACKAGE_NAME## PRIVATE -Wall)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  target_compile_options(##PACKAGE_NAME## PRIVATE -Wall -Wempty-body -Wmissing-field-initializers -Wtype-limits -Wuninitialized)
+  target_compile_options(##PACKAGE_NAME## PRIVATE -Wall -Wempty-body -Wmissing-field-initializers -Wtype-limits -Wuninitialized -Wno-psabi)
 endif()

--- a/.Config/Templates.gen/CMake/Snippet_TargetCompileOptions_Default.txt
+++ b/.Config/Templates.gen/CMake/Snippet_TargetCompileOptions_Default.txt
@@ -1,7 +1,7 @@
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   target_compile_options(##PACKAGE_NAME## PRIVATE -W -Wall -Wtype-limits -Wuninitialized)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-target_compile_options(##PACKAGE_NAME## PRIVATE -Wall -Wempty-body -Wmissing-field-initializers -Wtype-limits -Wuninitialized)
+target_compile_options(##PACKAGE_NAME## PRIVATE -Wall -Wempty-body -Wmissing-field-initializers -Wtype-limits -Wuninitialized -Wno-psabi)
 target_link_libraries(##PACKAGE_NAME## PRIVATE optimized -s)
 if(CODE_COVERAGE)
   set( 


### PR DESCRIPTION
Never GCC's give a lot of irrelevant compiler warnings for some platforms. They are irrelevant as they warn about compatibility issues older than when the code in the framework was written.