### PR TITLE
Made git apply more tolerant of line endings and whitespace differences

### DIFF
--- a/.Config/FslBuildGen/BuildExternal/Tasks.py
+++ b/.Config/FslBuildGen/BuildExternal/Tasks.py
@@ -189,7 +189,7 @@ class GitApplyTask(GitBaseTask):
 
     def RunGitApply(self, sourcePatchFile: str, targetPath: str) -> None:
         self.LogPrint("Running git apply {0} in {1}".format(sourcePatchFile, targetPath))
-        buildCommand = [self.GitCommand, 'apply', sourcePatchFile, "--whitespace=fix"]
+        buildCommand = [self.GitCommand, 'apply', sourcePatchFile, "--whitespace=fix", "--ignore-space-change", "--ignore-whitespace"]
         if self.Log.Verbosity > 0:
             buildCommand.append("-v")
         result = subprocess.call(buildCommand, cwd=targetPath)

--- a/.Config/FslBuildGen/Tool/ToolAppMain.py
+++ b/.Config/FslBuildGen/Tool/ToolAppMain.py
@@ -73,7 +73,7 @@ from FslBuildGen.Tool.ToolCommonArgConfig import ToolCommonArgConfig
 from FslBuildGen.Xml.Project.XmlProjectRootConfigFile import XmlProjectRootConfigFile
 
 
-CurrentVersion = Version(3, 7, 1, 7)
+CurrentVersion = Version(3, 7, 1, 8)
 
 
 def __AddDefaultOptions(parser: argparse.ArgumentParser, allowStandaloneMode: bool) -> None:


### PR DESCRIPTION
Made git apply more tolerant of line endings and whitespace differencesin patch files.
This will make the patches much more compatible with patchset generated by either linux or windows.

Other earlier pull requests with patch files will need this to work consistently on windows 
